### PR TITLE
Allow specifying individual test suite files in CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@
 # vendor/
 
 # Ignore `go build` output
-tesh
+/tesh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Ignore `go build` output
+tesh

--- a/pkg/tesh/parser.go
+++ b/pkg/tesh/parser.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/mickael-menu/tesh/pkg/internal/util/errors"
 )
 
 func ParseSuite(rootDir string) (TestSuiteNode, error) {
@@ -50,7 +52,7 @@ func ParseSuiteSingleFile(path string) (TestSuiteNode, error) {
 	var suite TestSuiteNode
 
 	if filepath.Ext(path) != ".tesh" {
-		return suite, nil
+		return suite, errors.New("file should be tesh file")
 	}
 
 	abs, err := filepath.Abs(path)

--- a/pkg/tesh/parser.go
+++ b/pkg/tesh/parser.go
@@ -43,6 +43,33 @@ func ParseSuite(rootDir string) (TestSuiteNode, error) {
 	return suite, err
 }
 
+// ParseSuiteSingleFile parses a single test file.
+// Unlike ParseSuite, which targets a directory, this function expects
+// a direct path to a .tesh file.
+func ParseSuiteSingleFile(path string) (TestSuiteNode, error) {
+	var suite TestSuiteNode
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return suite, err
+	}
+
+	abs := filepath.Join(dir, path)
+	if filepath.Ext(path) != ".tesh" {
+		return suite, nil
+	}
+
+	test, err := ParseTestFile(abs)
+	if err != nil {
+		return suite, err
+	}
+
+	test.Name = path
+	test.Path = abs
+	suite.Tests = append(suite.Tests, test)
+	return suite, nil
+}
+
 func ParseTestFile(path string) (TestNode, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/tesh/parser.go
+++ b/pkg/tesh/parser.go
@@ -49,16 +49,14 @@ func ParseSuite(rootDir string) (TestSuiteNode, error) {
 func ParseSuiteSingleFile(path string) (TestSuiteNode, error) {
 	var suite TestSuiteNode
 
-	dir, err := os.Getwd()
-	if err != nil {
-		return suite, err
-	}
-
-	abs := filepath.Join(dir, path)
 	if filepath.Ext(path) != ".tesh" {
 		return suite, nil
 	}
 
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return suite, err
+	}
 	test, err := ParseTestFile(abs)
 	if err != nil {
 		return suite, err

--- a/tesh.go
+++ b/tesh.go
@@ -33,7 +33,16 @@ func main() {
 		exitIfErr(err)
 	}
 
-	suite, err := tesh.ParseSuite(testsDir)
+	fileInfo, err := os.Stat(testsDir)
+	exitIfErr(err)
+
+	var suite tesh.TestSuiteNode
+
+	if fileInfo.IsDir() {
+		suite, err = tesh.ParseSuite(testsDir)
+	} else {
+		suite, err = tesh.ParseSuiteSingleFile(testsDir)
+	}
 	exitIfErr(err)
 	report, err := tesh.RunSuite(suite, tesh.RunConfig{
 		Update:     update,


### PR DESCRIPTION

## Summary
Updated `tesh` to accept individual `.tesh` files as command-line arguments in addition to directories.

## Background
Currently, `tesh` only accepts directory paths. This is inconvenient when a specific test suite fails, as it forces the user to run all suites within the directory to verify a single fix. This change improves the development workflow by allowing targeted test execution.

## Changes

* Modified the argument parser to handle both file and directory paths.
* If a file path is provided, `tesh` will execute only that specific test suite.
* Existing behavior for directory-based execution remains unchanged.

## Verification

I have verified the behavior in the `zk-org/zk` directory using the following commands:

```sh
# 1. Directory input (standard behavior)
PATH="$PWD:$PATH" tesh tests tests/fixtures

# 2. File input (targeted execution)
PATH="$PWD:$PATH" tesh tests/cmd-config-list.tesh tests/fixtures

# 3. Non-existent file (error handling check)
PATH="$PWD:$PATH" tesh tests/tesh-not-found.tesh tests/fixtures

# 4. Not tesh file (error handling check)
PATH="$PWD:$PATH" tesh main.go  tests/fixtures
```
